### PR TITLE
Fixed HTTP auth with Chromium based browsers

### DIFF
--- a/chromeipass/background/init.js
+++ b/chromeipass/background/init.js
@@ -83,15 +83,16 @@ browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 });
 
 
-/**
- * Retrieve Credentials and try auto-login for HTTPAuth requests
- *
- * (Intercepting HTTP auth currently unsupported in Firefox.)
- */
+// Retrieve Credentials and try auto-login for HTTPAuth requests
 if (browser.webRequest.onAuthRequired) {
-	browser.webRequest.onAuthRequired.addListener(httpAuth.handleRequest,
-													{ urls: ["<all_urls>"] }, ["blocking"]
-													);
+	if (isFirefox) {
+		browser.webRequest.onAuthRequired.addListener(httpAuth.handleRequest, 
+			{ urls: ["<all_urls>"] }, ["blocking"]);
+	}
+	else {
+		browser.webRequest.onAuthRequired.addListener(httpAuth.handleRequestChrome, 
+			{ urls: ["<all_urls>"] }, ["asyncBlocking"]);
+	}
 }
 
 /**

--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -1714,3 +1714,14 @@ cipEvents.triggerActivatedTab = function() {
 		}).then(cip.retrieveCredentialsCallback);
 	}
 }
+
+// Detect div's that include forms and are visible
+$(function() {
+	const divDetect = setInterval(function() {
+		const fields = cipFields.getAllFields();
+		if (fields.length > 0) {
+			cip.initCredentialFields(true);
+			clearInterval(divDetect);
+		}
+	}, 1000);
+});

--- a/chromeipass/global.js
+++ b/chromeipass/global.js
@@ -1,0 +1,4 @@
+var isFirefox = false;
+if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
+	isFirefox = true;
+}

--- a/chromeipass/manifest.json
+++ b/chromeipass/manifest.json
@@ -28,6 +28,7 @@
 	"background": {
 		"scripts": [
 			"browser-polyfill.min.js",
+			"global.js",
 			"background/aes.js",
 			"background/cryptoHelpers.js",
 			"background/utf8.js",
@@ -44,6 +45,7 @@
 			"matches": ["http://*/*", "https://*/*"],
 			"js": [
 				"browser-polyfill.min.js",
+				"global.js",
 				"jquery-1.11.1.min.js",
 				"jquery-ui-1.10.2.custom.min.js",
 				"chromeipass.js"

--- a/chromeipass/options/options.html
+++ b/chromeipass/options/options.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../bootstrap-btn.css" />
 		<link href="bootstrap-responsive.min.css" rel="stylesheet" />
 		<script type="text/javascript" src="../browser-polyfill.min.js"></script>
+		<script type="text/javascript" src="../global.js"></script>
 		<script type="text/javascript" src="../jquery-1.11.1.min.js"></script>
 		<script type="text/javascript" src="bootstrap.min.js"></script>
 		<script type="text/javascript" src="options.js"></script>

--- a/chromeipass/options/options.js
+++ b/chromeipass/options/options.js
@@ -296,7 +296,6 @@ options.initSpecifiedCredentialFields = function() {
 options.initAbout = function() {
 	var manifest = browser.runtime.getManifest();
 	$("#tab-about em.versionCIP").text(manifest.version);
-	//if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
 	if (isFirefox) {
 		/* Not Chrome or Chromium  */
 		$("#chrome-web-store-link").remove();

--- a/chromeipass/options/options.js
+++ b/chromeipass/options/options.js
@@ -296,7 +296,8 @@ options.initSpecifiedCredentialFields = function() {
 options.initAbout = function() {
 	var manifest = browser.runtime.getManifest();
 	$("#tab-about em.versionCIP").text(manifest.version);
-	if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
+	//if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
+	if (isFirefox) {
 		/* Not Chrome or Chromium  */
 		$("#chrome-web-store-link").remove();
 	}


### PR DESCRIPTION
This fixes the HTTP auth with Chromium based browsers. For some reason Chromium cannot understand a promise returned from a blocking HTTP auth request (even with mozilla-polyfill). This is a workaround until there's a better solution available.